### PR TITLE
Release 10.4.0 rc2

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,6 +6,7 @@ def main(ctx):
       'tarball': 'https://download.owncloud.com/internal/10.3.2/owncloud-enterprise-complete-20191205.tar.bz2',
       'tarball_sha': 'b3d880b3d1aec6834527fa3e671cf931c9d3b42150f68071ed29021e724b54f7',
       'php': '7.3',
+      'behat_version': '10.3.2',
       'base': 'v19.10',
       'tags': [],
     },
@@ -657,7 +658,7 @@ def api(config):
     'pull': 'always',
     'commands': [
       'mkdir -p vendor-bin/behat',
-      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']['value']),
+      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']),
       'cd vendor-bin/behat/ && composer install',
     ],
   },
@@ -712,7 +713,7 @@ def ui(config):
     'pull': 'always',
     'commands': [
       'mkdir -p vendor-bin/behat',
-      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']['value']),
+      'wget -O vendor-bin/behat/composer.json https://raw.githubusercontent.com/owncloud/core/%s/vendor-bin/behat/composer.json' % versionize(config['version']),
       'cd vendor-bin/behat/ && composer install',
     ],
   },
@@ -792,7 +793,8 @@ def cleanup(config):
   }]
 
 def versionize(version):
-    if version == 'latest':
-        return 'master'
-    else:
-        return 'v%s' % (version.replace("rc", "RC").replace("-", ""))
+  if 'behat_version' in version:
+    raw_version = version['behat_version']
+  else:
+    raw_version = version['value']
+  return 'v%s' % (raw_version.replace("rc", "RC").replace("-", ""))

--- a/.drone.star
+++ b/.drone.star
@@ -11,10 +11,10 @@ def main(ctx):
     },
 
     {
-      'value': '10.4.0-rc1',
-      'qa': 'https://download.owncloud.com/internal/10.4.0RC1/testing/owncloud-enterprise-complete-10.4.0RC1-qa.tar.bz2',
-      'tarball': 'https://download.owncloud.com/internal/10.4.0RC1/testing/owncloud-enterprise-complete-10.4.0RC1.tar.bz2',
-      'tarball_sha': '2e22e76b42af4a7981b1c63995f0fdffd8c22bc7a9684ed2f1c7c4bdda9394d5',
+      'value': '10.4.0-rc2',
+      'qa': 'https://download.owncloud.com/internal/10.4.0RC2/testing/owncloud-enterprise-complete-10.4.0RC2-qa.tar.bz2',
+      'tarball': 'https://download.owncloud.com/internal/10.4.0RC2/testing/owncloud-enterprise-complete-10.4.0RC2.tar.bz2',
+      'tarball_sha': '56db118919d14d93dd5de69eee8e6b89f51970fb79df43d02ad5c03ee9ec0270',
       'php': '7.3',
       'base': 'v19.10',
       'tags': [],

--- a/.drone.star
+++ b/.drone.star
@@ -9,6 +9,17 @@ def main(ctx):
       'base': 'v19.10',
       'tags': [],
     },
+
+    {
+      'value': '10.4.0-rc1',
+      'qa': 'https://download.owncloud.com/internal/10.4.0RC1/testing/owncloud-enterprise-complete-10.4.0RC1-qa.tar.bz2',
+      'tarball': 'https://download.owncloud.com/internal/10.4.0RC1/testing/owncloud-enterprise-complete-10.4.0RC1.tar.bz2',
+      'tarball_sha': '2e22e76b42af4a7981b1c63995f0fdffd8c22bc7a9684ed2f1c7c4bdda9394d5',
+      'php': '7.3',
+      'base': 'v19.10',
+      'tags': [],
+    },
+
     {
       'value': '10.3.2',
       'qa': 'https://download.owncloud.com/internal/10.3.2/testing/owncloud-enterprise-complete-20191205-qa.tar.bz2',
@@ -18,6 +29,7 @@ def main(ctx):
       'base': 'v19.10',
       'tags': ['10.3', '10'],
     },
+
     {
       'value': '10.2.1',
       'qa': 'https://download.owncloud.com/internal/10.2.1/owncloud-enterprise-complete-20190703-qa.tar.bz2',


### PR DESCRIPTION
Add new version entry `10.4.0-rc2`- this obsoletes https://github.com/owncloud-docker/enterprise/pull/30

This is the enterprise twin of https://github.com/owncloud-docker/server/pull/166